### PR TITLE
Add version number to GUI title

### DIFF
--- a/ml4bio/ml4bio.py
+++ b/ml4bio/ml4bio.py
@@ -14,6 +14,7 @@ from PyQt5.QtWidgets import QStackedWidget, QGroupBox, QFrame, QTableWidget, QTr
 from PyQt5.QtWidgets import QFormLayout, QGridLayout, QHBoxLayout, QVBoxLayout, QSpacerItem, QSizePolicy
 from PyQt5.QtGui import QFont, QIcon, QPixmap
 
+import ml4bio
 from ml4bio.data import Data
 from ml4bio.model import Model, DecisionTree, RandomForest, KNearestNeighbors, LogisticRegression, NeuralNetwork, SVM, NaiveBayes
 from ml4bio.model_metrics import ModelMetrics
@@ -2223,7 +2224,7 @@ class App(QMainWindow):
 
         # global geometry
         self.resize(1064, 700)
-        self.setWindowTitle('ML4Bio')
+        self.setWindowTitle('ML4Bio (version {})'.format(ml4bio.__version__))
         self.leftPanel.resize(360, 680)
         self.leftPanel.setStyleSheet("QStackedWidget {background-color:rgb(226, 226, 226)}")
         self.leftPanel.move(10, 10)


### PR DESCRIPTION
Partially addresses https://github.com/gitter-lab/ml-bio-workshop/issues/19

I'm requesting review before merging this small change to see if you like how the version is displayed:
![image](https://user-images.githubusercontent.com/3532898/49480623-05b72a80-f7ed-11e8-904e-f5e3ccab8139.png)

We could use `v0.1.1` or something else instead.