### PR TITLE
addressed issue 6

### DIFF
--- a/ml4bio/ml4bio.py
+++ b/ml4bio/ml4bio.py
@@ -1282,7 +1282,8 @@ class App(QMainWindow):
             data = self.data.prediction('one-hot')
 
         path = QFileDialog.getSaveFileName(self.testPage)[0]
-        self.curr_model.predict(data, path)
+        if path != '':
+            self.curr_model.predict(data, path)
 
     def finish(self):
         """


### PR DESCRIPTION
Fix the following bug:
If one clicks the "predict and save as" button but then cancels without specifying a file name, the GUI will crash.

Closes #6 